### PR TITLE
Remove Centarro Claro from the list of certified project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         }
     ],
     "require": {
-        "centarro/centarro_claro": "1.x-dev",
         "drupal/belgrade": "^2",
         "drupal/commerce_authnet": "^1.6",
         "drupal/commerce_avatax": "^1.1",


### PR DESCRIPTION
With Gin replacing Centarro Claro as the default admin theme, and the installer implementing its theme in https://www.drupal.org/project/commerce_kickstart/issues/3515126 we will retire Centarro Claro. One step is removing it from the list of certified projects.